### PR TITLE
Set expired TGT to empty string in local storage

### DIFF
--- a/src/components/MainNavBar/MainNavBar.tsx
+++ b/src/components/MainNavBar/MainNavBar.tsx
@@ -39,7 +39,7 @@ const MainNavBar = () => {
 
     if (currentTime - timeStamp > expirationDuration) {
       window.localStorage.removeItem("TGT");
-      setTgtValueFromStorage(null);
+      setTgtValueFromStorage("");
     }
   }
 


### PR DESCRIPTION
## MADiE PR

Jira Ticket: N/A
(Optional) Related Tickets:

### Summary
Setting the TGT value in local storage to null results in a read of a string containing the text "null" and not the value null.

This results in a truthy value causes the guard checks around TGT processing to get the string "null" instead of the TGT value.

Since empty string is falsey, opting to set the expired TGT to "" results in the guard check being skipped.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
