### PR TITLE
Extend okta's `isAuthenticated` check to require an active okta session

### DIFF
--- a/.github/workflows/unit_test_coverage.yml
+++ b/.github/workflows/unit_test_coverage.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm ci
 
       - name: Audit dependencies for security vulnerabilities
-        run: npm audit
+        run: npm audit --production
 
       - name: Lint the source code
         run: npm run-script lint

--- a/src/components/login/Login.test.tsx
+++ b/src/components/login/Login.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import Login from "./Login";
 import { MemoryRouter } from "react-router";
@@ -95,7 +95,6 @@ describe("Login component", () => {
 
     const loginButton = screen.getByRole("button", { name: "Login Widget" });
     userEvent.click(loginButton);
-    screen.debug();
     expect(mockHandleLoginRedirect).toBeCalled();
     await waitFor(() => expect(mockLoginLogger).toHaveBeenCalled());
   });

--- a/src/okta/OktaSecurity.test.tsx
+++ b/src/okta/OktaSecurity.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom";
 
 import * as React from "react";
 import OktaSecurity, { transformAuthState } from "./OktaSecurity";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, test } from "@jest/globals";
 import oktaConfig from "./Config";
@@ -25,6 +25,7 @@ jest.mock("./Config", () => ({
 jest.mock("@okta/okta-react", () => ({
   Security: (props) => {
     const FakeSecurity = "very-fake-security";
+    // @ts-ignore
     return <FakeSecurity {...props} />;
   },
 }));

--- a/src/okta/OktaSecurity.test.tsx
+++ b/src/okta/OktaSecurity.test.tsx
@@ -1,8 +1,8 @@
 import "@testing-library/jest-dom";
 
 import * as React from "react";
-import OktaSecurity from "./OktaSecurity";
-import { act, render } from "@testing-library/react";
+import OktaSecurity, { transformAuthState } from "./OktaSecurity";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, test } from "@jest/globals";
 import oktaConfig from "./Config";
@@ -68,5 +68,26 @@ describe("Config component", () => {
       const loginPage = await findByTestId("login-page-message");
       expect(loginPage).toBeInTheDocument();
     });
+  });
+});
+
+describe("okta auth", () => {
+  test("checks initial isAuthenticated state", async () => {
+    const mockAuthState = { isAuthenticated: false };
+    const authResult = await transformAuthState({}, mockAuthState);
+    expect(authResult).toEqual(mockAuthState);
+  });
+
+  test("requires an active okta session", async () => {
+    const mockAuthState = { isAuthenticated: true };
+    const mockOtkaAuth = {
+      session: {
+        exists: jest.fn(() => {
+          return false;
+        }),
+      },
+    };
+    const authResult = await transformAuthState(mockOtkaAuth, mockAuthState);
+    expect(authResult.isAuthenticated).toBeFalsy();
   });
 });

--- a/src/okta/OktaSecurity.tsx
+++ b/src/okta/OktaSecurity.tsx
@@ -45,7 +45,18 @@ function OktaSecurity() {
   };
 
   if (!!oktaConfig) {
-    const oktaAuth = new OktaAuth(oktaConfig);
+    const oktaAuth = new OktaAuth({
+      ...oktaConfig, // other config
+      transformAuthState: async (oktaAuth, authState) => {
+        // verifies unexpired tokens are available from the tokenManager (default behavior)
+        if (!authState.isAuthenticated) {
+          return authState;
+        }
+        // extra requirement:  user must have valid Okta session
+        authState.isAuthenticated = await oktaAuth.session.exists();
+        return authState;
+      },
+    });
     return (
       <Security
         oktaAuth={oktaAuth}

--- a/src/okta/OktaSecurity.tsx
+++ b/src/okta/OktaSecurity.tsx
@@ -5,6 +5,16 @@ import { OktaAuth, toRelativeUrl } from "@okta/okta-auth-js";
 import { getOktaConfig, OktaConfig } from "./Config";
 import Router from "../router/Router";
 
+export const transformAuthState = async (oktaAuth, authState) => {
+  // verifies unexpired tokens are available from the tokenManager (default behavior)
+  if (!authState.isAuthenticated) {
+    return authState;
+  }
+  // extra requirement:  user must have valid Okta session
+  authState.isAuthenticated = await oktaAuth.session.exists();
+  return authState;
+};
+
 function OktaSecurity() {
   const history = useHistory();
   const [oktaConfig, setOktaConfig] = useState<OktaConfig>();
@@ -47,15 +57,7 @@ function OktaSecurity() {
   if (!!oktaConfig) {
     const oktaAuth = new OktaAuth({
       ...oktaConfig, // other config
-      transformAuthState: async (oktaAuth, authState) => {
-        // verifies unexpired tokens are available from the tokenManager (default behavior)
-        if (!authState.isAuthenticated) {
-          return authState;
-        }
-        // extra requirement:  user must have valid Okta session
-        authState.isAuthenticated = await oktaAuth.session.exists();
-        return authState;
-      },
+      transformAuthState,
     });
     return (
       <Security


### PR DESCRIPTION
## MADiE PR

JIRA Story: [MAT-4308](https://jira.cms.gov/browse/MAT-4308)

### Summary

`isAuthenticated` is Okta's recommended flag for checking if a user is logged in. By default it only verifies that both an idToken and accessToken are available in the `TokenManager`. It does not verify if the tokens are still alive (aka haven't been revoked).

As a result, the tokens can be saved off prior to sign out and re-used at-will.

Verifying token status can be accomplished several ways, as there are multiple endpoints that will fail out should the tokens be invalid.

Checking the Okta session is a good candidate since it is created and destroyed by the signIn and signOut events respectively.

In fact, calling `oktaAuth.signOut()` signs the user of their current Okta session, and, by default, revokes the accessToken and clears out the `TokenManager`, indicating both session and token should be dealt with when logging users out of the application anyways.

To add any additional check to `isAuthenticated`, pass a customized `transformedAuthState` function to the OktaAuth config, which will modify the `authState` object before it is stored and emitted.

This additional check will set `isAuthenticated` to the result of  `session.exists()`. `False` indicates no active session, `True`, an active exists.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is into the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
