### PR TITLE
Mat-4491: Implement Route Change blocker and warning lose progress dialog

### DIFF
--- a/src/__mocks__/@madie/madie-util.tsx
+++ b/src/__mocks__/@madie/madie-util.tsx
@@ -11,3 +11,10 @@ export const measureStore = {
   subscribe: () => null, // needs to return an object with key subscribe
   unsubscribe: () => null,
 };
+
+export const routeHandlerStore = {
+  initialState: { canTravel: true, pendingRoute: "" },
+  state: { canTravel: true, pendingRoute: "" },
+  subscribe: () => null, // needs to return an object with key subscribe
+  unsubscribe: () => null,
+};

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -77,7 +77,7 @@ const PageHeader = () => {
         </Fade>
       )}
       {/* state 2 */}
-      {pathname === "/measures" && (
+      {(pathname === "/measures" || pathname === "/measures/") && (
         <div className="measures">
           <CreateNewMeasureDialog open={createOpen} onClose={handleClose} />
           <div>

--- a/src/router/RouteChangeHandler.scss
+++ b/src/router/RouteChangeHandler.scss
@@ -1,0 +1,35 @@
+.route-change-dialog-body {
+  font-family: Rubik;
+  padding: 12px 8px;
+  display: flex;
+  flex-direction: column;
+
+  .dialog-warning-body {
+    font-size: 16px;
+    line-height: 19px;
+
+    p {
+      margin-bottom: 18px;
+    }
+
+    .strong {
+      font-weight: 500;
+    }
+  }
+
+  .dialog-warning-action {
+    font-size: 14px;
+    line-height: 26px;
+    font-weight: 400;
+    color: #d92f2f;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: -3px;
+
+    > p {
+      margin-left: 8px;
+      margin-bottom: 0;
+    }
+  }
+}

--- a/src/router/RouteChangeHandler.scss
+++ b/src/router/RouteChangeHandler.scss
@@ -1,5 +1,5 @@
 .route-change-dialog-body {
-  font-family: Rubik;
+  font-family: Rubik, sans-serif;
   padding: 12px 8px;
   display: flex;
   flex-direction: column;

--- a/src/router/RouteChangeHandler.tsx
+++ b/src/router/RouteChangeHandler.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from "react";
+import { useHistory } from "react-router-dom";
+import { MadieDialog } from "@madie/madie-design-system/dist/react";
+import { routeHandlerStore } from "@madie/madie-util";
+import ErrorIcon from "@mui/icons-material/Error";
+// import { RouteHandlerState } from "../types/madie-madie-util";
+import "./RouteChangeHandler.scss";
+// We have to listen at the top level for navigational changes to block them.
+// Navigation must be aware of dirty form state.
+export interface RouteHandlerState {
+  canTravel: boolean;
+  pendingRoute: string;
+}
+
+const RouteChangePrompt = () => {
+  const { updateRouteHandlerState } = routeHandlerStore;
+  const [routeHandlerState, setRouteHandlerState] = useState<RouteHandlerState>(
+    routeHandlerStore.state
+  );
+
+  useEffect(() => {
+    const subscription = routeHandlerStore.subscribe(setRouteHandlerState);
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const history = useHistory();
+  const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    const unblock = history.block(({ pathname }) => {
+      if (!routeHandlerState.canTravel) {
+        updateRouteHandlerState({ canTravel: true, pendingRoute: pathname });
+        return false;
+      }
+      unblock();
+    });
+    return unblock;
+  }, [
+    setDialogOpen,
+    history.block,
+    routeHandlerState.canTravel,
+    routeHandlerState.pendingRoute,
+  ]);
+
+  useEffect(() => {
+    if (routeHandlerState.pendingRoute) {
+      setDialogOpen(true);
+      setRouteHandlerState({
+        canTravel: true,
+        pendingRoute: routeHandlerState.pendingRoute,
+      });
+    }
+  }, [routeHandlerState.pendingRoute, setDialogOpen]);
+
+  const onContinue = () => {
+    setDialogOpen(false);
+    const currentRoute = routeHandlerState.pendingRoute;
+    updateRouteHandlerState({
+      canTravel: true,
+      pendingRoute: currentRoute,
+    });
+    history.push(routeHandlerState.pendingRoute);
+  };
+  const onClose = () => {
+    updateRouteHandlerState({ canTravel: false, pendingRoute: "" });
+    setDialogOpen(false);
+  };
+
+  return (
+    <div>
+      <MadieDialog
+        title="Discard Changes?"
+        dialogProps={{
+          open: dialogOpen,
+          onClose,
+          "data-testid": "discard-dialog",
+        }}
+        cancelButtonProps={{
+          variant: "secondary",
+          onClick: onClose,
+          cancelText: "No, Keep Working",
+          "data-testid": "discard-dialog-cancel-button",
+        }}
+        continueButtonProps={{
+          variant: "primary",
+          type: "submit",
+          "data-testid": "discard-dialog-continue-button",
+          continueText: "Yes, Discard All Changes",
+          onClick: onContinue,
+        }}
+      >
+        <div className="route-change-dialog-body">
+          <section className="dialog-warning-body">
+            <p>You have unsaved changes.</p>
+            <p className="strong">
+              Are you sure you want to discard your changes?
+            </p>
+          </section>
+          <section className="dialog-warning-action">
+            <ErrorIcon />
+            <p>This Action cannot be undone.</p>
+          </section>
+        </div>
+      </MadieDialog>
+    </div>
+  );
+};
+export default RouteChangePrompt;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -10,6 +10,7 @@ import Footer from "../components/Footer/Footer";
 import PageHeader from "../components/PageHeader/PageHeader";
 import "../styles/LayoutStyles.scss";
 import TimeoutHandler from "../components/timeoutHandler/TimeoutHandler";
+import RouteChangeHandler from "./RouteChangeHandler";
 
 function Router({ props }) {
   const { authState } = useOktaAuth();
@@ -21,6 +22,7 @@ function Router({ props }) {
       <BrowserRouter>
         <MainNavBar />
         <PageHeader />
+        <RouteChangeHandler />
         <div id="page-content">
           <Switch>
             <Route

--- a/src/types/madie-madie-util.d.ts
+++ b/src/types/madie-madie-util.d.ts
@@ -21,6 +21,11 @@ declare module "@madie/madie-util" {
     };
   }
 
+  export interface RouteHandlerState {
+    canTravel: boolean;
+    pendingRoute: string;
+  }
+
   export const measureStore: {
     subscribe: (
       setMeasureState: React.Dispatch<React.SetStateAction<Measure>>
@@ -28,6 +33,15 @@ declare module "@madie/madie-util" {
     updateMeasure: (measure: Measure | null) => void;
     initialState: null;
     state: Measure;
+  };
+
+  export const routeHandlerStore: {
+    subscribe: (
+      setRouteHandlerState: React.Dispatch<React.SetStateAction<object>>
+    ) => import("rxjs").Subscription;
+    updateRouteHandlerState: (routeHandlerState: RouteHandlerState) => void;
+    initialState: RouteHandlerState;
+    state: RouteHandlerState;
   };
 
   export function getServiceConfig(): Promise<ServiceConfig>;


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4491](https://jira.cms.gov/browse/MAT-4491)
(Optional) Related Tickets:

### Summary
![image](https://user-images.githubusercontent.com/84744653/183974122-a8f767d7-aac2-4b50-9122-b659f6ff33ba.png)
Create route blocking hook that prevents users from navigating when forms are dirty regardless of spa app.
Whenever a pending route is discovered, open a warning dialog to prevent loss until user is willing to accept risk.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
