### PR TITLE
MAT-5108: Update layout to use new onFocus helperText rules.

### DIFF
--- a/src/components/NewMeasure/CreateNewMeasureDialog.test.tsx
+++ b/src/components/NewMeasure/CreateNewMeasureDialog.test.tsx
@@ -258,9 +258,8 @@ describe("Measures Create Dialog", () => {
         ).toHaveTextContent(
           "Start date should be between the years 1900 and 2099"
         );
+        expect(screen.getByTestId("continue-button")).toBeDisabled();
       });
-
-      expect(screen.getByTestId("continue-button")).toBeDisabled();
     });
   });
 

--- a/src/components/NewMeasure/CreateNewMeasureDialog.tsx
+++ b/src/components/NewMeasure/CreateNewMeasureDialog.tsx
@@ -121,6 +121,16 @@ const CreateNewMeasureDialog = ({ open, onClose }) => {
     },
   };
   const formRowGapped = Object.assign({}, formRow, gap);
+  // we create a state to track current focus. We only display helper text on focus and remove current focus on blur
+  const [focusedField, setFocusedField] = useState("");
+  const onBlur = (field) => {
+    setFocusedField("");
+    formik.setFieldTouched(field);
+  };
+  const onFocus = (field) => {
+    setFocusedField(field);
+  };
+
   return (
     <MadieDialog
       form
@@ -191,6 +201,7 @@ const CreateNewMeasureDialog = ({ open, onClose }) => {
       />
       <Box sx={formRow}>
         <TextField
+          onFocus={() => onFocus("measureName")}
           placeholder="Measure Name"
           required
           label="Measure Name"
@@ -200,18 +211,26 @@ const CreateNewMeasureDialog = ({ open, onClose }) => {
             "aria-describedby": "measureName-helper-text",
             required: true,
           }}
-          helperText={formikErrorHandler("measureName", true)}
+          helperText={
+            (formik.touched["measureName"] || focusedField === "measureName") &&
+            (formikErrorHandler("measureName", true) ||
+              "Measure Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters.")
+          }
           data-testid="measure-name-text-field"
           size="small"
           error={
             formik.touched.measureName && Boolean(formik.errors.measureName)
           }
           {...formik.getFieldProps("measureName")}
+          onBlur={() => {
+            onBlur("measureName");
+          }}
         />
       </Box>
 
       <Box sx={formRow}>
         <TextField
+          onFocus={() => onFocus("cqlLibraryName")}
           placeholder="Enter CQL Library Name"
           required
           label="Measure CQL Library Name"
@@ -222,13 +241,21 @@ const CreateNewMeasureDialog = ({ open, onClose }) => {
             "aria-describedby": "cqlLibraryName-helper-text",
             required: true,
           }}
-          helperText={formikErrorHandler("cqlLibraryName", true)}
+          helperText={
+            (formik.touched["cqlLibraryName"] ||
+              focusedField === "cqlLibraryName") &&
+            (formikErrorHandler("cqlLibraryName", true) ||
+              "Measure Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters.")
+          }
           size="small"
           error={
             formik.touched.cqlLibraryName &&
             Boolean(formik.errors.cqlLibraryName)
           }
           {...formik.getFieldProps("cqlLibraryName")}
+          onBlur={() => {
+            onBlur("cqlLibraryName");
+          }}
         />
       </Box>
 
@@ -319,6 +346,7 @@ const CreateNewMeasureDialog = ({ open, onClose }) => {
               );
               return (
                 <TextField
+                  onFocus={() => onFocus("measurementPeriodStart")}
                   id="create-measure-period-start"
                   {...formikFieldProps}
                   {...params}
@@ -328,15 +356,18 @@ const CreateNewMeasureDialog = ({ open, onClose }) => {
                     formik.touched.measurementPeriodStart &&
                     Boolean(formik.errors.measurementPeriodStart)
                   }
-                  helperText={formikErrorHandler(
-                    "measurementPeriodStart",
-                    true
-                  )}
+                  helperText={
+                    (formik.touched["measurementPeriodStart"] ||
+                      focusedField === "measurementPeriodStart") &&
+                    (formikErrorHandler("measurementPeriodStart", true) ||
+                      "Start date should be between the years 1900 and 2099.")
+                  }
                   InputProps={{
                     "data-testid": "measurement-period-start-input",
                     "aria-describedby":
                       "create-measure-period-start-helper-text",
                   }}
+                  onBlur={() => onBlur("measurementPeriodStart")}
                 />
               );
             }}
@@ -358,6 +389,7 @@ const CreateNewMeasureDialog = ({ open, onClose }) => {
               return (
                 <TextField
                   id="create-measure-period-end"
+                  onFocus={() => onFocus("measurementPeriodEnd")}
                   {...formikFieldProps}
                   {...params}
                   required
@@ -366,12 +398,18 @@ const CreateNewMeasureDialog = ({ open, onClose }) => {
                     formik.touched.measurementPeriodEnd &&
                     Boolean(formik.errors.measurementPeriodEnd)
                   }
-                  helperText={formikErrorHandler("measurementPeriodEnd", true)}
+                  helperText={
+                    (formik.touched["measurementPeriodEnd"] ||
+                      focusedField === "measurementPeriodEnd") &&
+                    (formikErrorHandler("measurementPeriodEnd", true) ||
+                      "End date should be between the years 1900 and 2099.")
+                  }
                   InputProps={{
                     "data-testid": "measurement-period-end-input",
                     "aria-describedby": "create-measure-period-end-helper-text",
                     required: true,
                   }}
+                  onBlur={() => onBlur("measurementPeriodEnd")}
                 />
               );
             }}

--- a/src/components/NewMeasure/CreateNewMeasureDialog.tsx
+++ b/src/components/NewMeasure/CreateNewMeasureDialog.tsx
@@ -214,7 +214,7 @@ const CreateNewMeasureDialog = ({ open, onClose }) => {
           helperText={
             (formik.touched["measureName"] || focusedField === "measureName") &&
             (formikErrorHandler("measureName", true) ||
-              "Measure Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters.")
+              "Measure Name must contain at least one letter and must not contain '_' (underscores).")
           }
           data-testid="measure-name-text-field"
           size="small"

--- a/src/models/MeasureSchemaValidator.ts
+++ b/src/models/MeasureSchemaValidator.ts
@@ -4,9 +4,9 @@ import { isWithinInterval } from "date-fns";
 
 export const MeasureSchemaValidator = Yup.object().shape({
   measureName: Yup.string()
-    .max(500, "A Measure Name cannot be more than 500 characters.")
-    .required("A Measure Name is required.")
-    .matches(/[a-zA-Z]/, "A Measure Name must contain at least one letter.")
+    .max(500, "Measure Name cannot be more than 500 characters.")
+    .required("Measure Name is required.")
+    .matches(/[a-zA-Z]/, "Measure Name must contain at least one letter.")
     .matches(/^((?!_).)*$/, "Measure Name must not contain '_' (underscores)."),
   model: Yup.string()
     .oneOf(Object.values(Model))


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5108](https://jira.cms.gov/browse/MAT-5108)
(Optional) Related Tickets:

### Summary
508 Tester wants helper text to display on focus whenever there's a type of rule that would be useful for the user to know for entering information.
I elected to use the most helperText like of the validation tests to display on focus, and on blur default to an error state should there be one.

I omitted a helper text for uncommon states such as entering too many characters (32) for the abbreviation as that feels much more like a validation than helper text info

This PR also fixes a bug with the tests that only appeared after adding an on blur event as it wasn't set up within an async check.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is into the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
